### PR TITLE
Fix numpy loading pickled data

### DIFF
--- a/src/repositories/radar/config.py
+++ b/src/repositories/radar/config.py
@@ -83,7 +83,8 @@ floorsPathsImgs = [
     loadFromRGBToGray(
         f'{currentPath}/images/paths/floor-15.png'),
 ]
-floorsPathsSqms = np.load(f'{currentPath}/npys/floorsPathsSqms.npy')
+floorsPathsSqms = np.load(
+    f'{currentPath}/npys/floorsPathsSqms.npy', allow_pickle=True)
 images = {
     'tools': loadFromRGBToGray(f'{currentPath}/images/buttons/radarTools.png')
 }


### PR DESCRIPTION
## Summary
- ensure allow_pickle=True when loading floorsPathsSqms

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pyautogui')*

------
https://chatgpt.com/codex/tasks/task_b_688d1d538b34832c8341f32b4547cad5